### PR TITLE
Fixes broken link to documentation

### DIFF
--- a/docs/commands/site.md
+++ b/docs/commands/site.md
@@ -185,7 +185,7 @@ export CF_Email="xxxx@sss.com"
 ```
 
 !!! info
-    More example in our guide about [DNS API configuration](/how-to/configure-letsencrypt-dns-api-validation.md)
+    More example in our guide about [DNS API configuration](/how-to/configure-letsencrypt-dns-api-validation)
 
 After you define those variables with the command `export`, you can issue your certificate with
 


### PR DESCRIPTION
The link to documentation entry "Let's Encrypt DNS API configuration" found at https://docs.wordops.net/how-to/configure-letsencrypt-dns-api-validation/ was broken on this page, due to the link having an errant ".md" at the end. 

Updated the URL to prevent users from encountering a 404 when following the info box link about DNS API configuration