### PR TITLE
Fix typo

### DIFF
--- a/docs/how-to/post-install-wp.md
+++ b/docs/how-to/post-install-wp.md
@@ -1,5 +1,3 @@
-# WordPress post-install automation
-
 There are multiple, viable approaches to automate post-installation of a WordPress blog using WordOps, without the need of adding new commands or increasing overall complexity.
 
 For this tutorial, we're going to show how to automatically install plugins and themes from official WordPress repository, as well as how to install custom plugins and themes, not available at wordpress.org.
@@ -61,13 +59,14 @@ cd -
 
 exit 0
 ```
-
 ### Example of how to use the script
 
 ```bash
 # install the blog
 wo site create thedomain.com --wpredis --php73
-/scriprs/post-wp-install.sh thedomain.com
+
+# run the script
+/scripts/post-wp-install.sh thedomain.com
 ```
 
 ### Notes about the script


### PR DESCRIPTION
There was a typo in sample code, preventing it from working for copy and paste cases.