### PR TITLE
Update guides.md

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -16,8 +16,8 @@ Here the list of guides about WordOps available in this documentation:
 
 - [Install fast WordPress site on Ubuntu using WordOps - MARKO NTECH](https://markontech.com/wordpress/install-wordpress-on-ubuntu-using-wordops/)
 - [High traffic WordPress architecture using AWS Lightsail - David Vekslermkd](https://davidveksler.com/2019/10/20/high-traffic-wordpress-architecture-using-aws-lightsail/)
-- [Why You Should Avoid Shared Hosting and Try Nginx with WordOps - Matt](https://www.codecoffee.com/avoid-shared-hosting-try-nginx-wordops/)
 - [Build a Super Optimized WordPress site with WordOps - Varma](https://tutorialforest.com/build-performance-optimized-wordpress-wordops)
+- [Install WordPress Automatically on Ubuntu 20.04 using WordOps](https://bytexd.com/wordops-ubuntu/)
 
 ### French
 


### PR DESCRIPTION
Added a tutorial on using WordOps. Written by me - [Install WordPress Automatically on Ubuntu 20.04 using WordOps](https://bytexd.com/wordops-ubuntu/)

Removed a link that now 301 redirects to an article unrelated to WordOps ( https://macinfo.us/how-to-access-blocked-websites-on-a-mac/ )