### PR TITLE
Instructions to allow FTP with firewall

### DIFF
--- a/docs/how-to/add-ftp-users.md
+++ b/docs/how-to/add-ftp-users.md
@@ -34,6 +34,6 @@ chmod -R g+rw /var/www/wordops.net/htdocs
 If you are using UFW, you must allow the FTP port and some passive ports:
 
 ```
-sudo ufw allow 21
-sudo ufw allow 49000:50000/tcp
+ufw allow 21
+ufw allow 49000:50000/tcp
 ```

--- a/docs/how-to/add-ftp-users.md
+++ b/docs/how-to/add-ftp-users.md
@@ -28,3 +28,12 @@ There is another step to allow our new user to upload/edit files :
 ```bash
 chmod -R g+rw /var/www/wordops.net/htdocs
 ```
+
+## Firewall configuration
+
+If you are using UFW, you must allow the FTP port and some passive ports:
+
+```
+sudo ufw allow 21
+sudo ufw allow 49000:50000/tcp
+```


### PR DESCRIPTION
PR to include the following text in https://docs.wordops.net/how-to/add-ftp-users/ :

If you are using UFW, you must allow the FTP port and some passive ports:

```
ufw allow 21
ufw allow 49000:50000/tcp
```