### PR TITLE
Update wp-language.md

### DIFF
--- a/docs/how-to/wp-language.md
+++ b/docs/how-to/wp-language.md
@@ -24,4 +24,7 @@ In order to avoid such inconsistence, perhaps it's wiser to install WP in `en_US
 ```bash
 cd /var/www/example.com/htdocs
 wp language core install pt_BR --activate --allow-root
+cd wp-content
+chown www-data:www-data languages -R
+# the languages folder is created with owner / group root by the wp language call, this allows update of translations from the dashboard updates page
 ```


### PR DESCRIPTION
Added a call to 'chown' to the code to change the site language post install. If omitted the languages folder is owned by root and update translations won't work.